### PR TITLE
Support access_token cookie and improve error handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ description = "Glue token validation + user service to provide identity context 
 name = "ab-identity-context"
 readme = "README.md"
 requires-python = ">=3.12,<4.0"
-version = "0.2.0"
+version = "0.2.1"
 
 [project.optional-dependencies]
 all = [

--- a/src/ab_core/identity_context/dependency.py
+++ b/src/ab_core/identity_context/dependency.py
@@ -3,7 +3,7 @@
 from typing import Annotated
 
 try:
-    from fastapi import Header, HTTPException, status
+    from fastapi import Cookie, Header, HTTPException, status
 except ImportError as e:
     raise RuntimeError(
         "`ab_core.identity_context.dependency::get_identity_context` requires FastAPI dependency."
@@ -16,23 +16,29 @@ from .models import IdentityContext
 
 
 async def get_identity_context(
+    access_token: Annotated[str | None, Cookie(alias="access_token")] = None,
     authorization: Annotated[str | None, Header()] = None,
 ) -> IdentityContext:
     """FastAPI dependency that returns IdentityContext.
 
     Usage:
-        identity: Annotated[IdentityContext, Depends(identity_context)]
+        identity: Annotated[IdentityContext, Depends(get_identity_context)]
     """
-    if not authorization or not authorization.lower().startswith("bearer "):
+    token: str | None = None
+
+    if access_token:
+        token = access_token
+    elif authorization and authorization.lower().startswith("bearer "):
+        _, token = authorization.split(" ", 1)
+
+    if not token:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Missing bearer token",
+            detail="Missing access token",
         )
-    _, token = authorization.split(" ", 1)
+
     try:
-        return await identify(
-            token=token,
-        )
+        return await identify(token=token)
     except IdentificationError as e:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/src/ab_core/identity_context/identify.py
+++ b/src/ab_core/identity_context/identify.py
@@ -2,16 +2,17 @@
 
 from typing import Annotated
 
-
 from ab_client.token_validator import (
     AsyncClient as TokenValidatorClient,
+)
+from ab_client.token_validator import (
     ValidateTokenRequest,
-    ValidatedOIDCClaims,
 )
 from ab_client.user import (
     AsyncClient as UserClient,
+)
+from ab_client.user import (
     UpsertByOIDCRequest,
-    User,
 )
 
 from ab_core.dependency import Depends, inject, pydanticize_type
@@ -36,24 +37,35 @@ async def identify(
         Depends(ObjectLoaderEnvironment[pydanticize_type(UserClient)](env_prefix="USER_CLIENT"), persist=True),
     ],
 ) -> IdentityContext:
-    """Identity a user given a valid token."""
+    """Identity a user given a valid token.
+
+    Raises:
+        IdentificationError: If token validation or user upsert fails.
+
+    """
     # 1. validate the token
-    claims = await token_validator_client.validate_token_validate_post(
-        data=ValidateTokenRequest(
-            token=token,
-        ),
-    )
+    try:
+        claims = await token_validator_client.validate_token_validate_post(
+            data=ValidateTokenRequest(
+                token=token,
+            ),
+        )
+    except Exception as e:
+        raise IdentificationError("Token validation failed") from e
 
     # 2. upsert the user
-    user = await user_client.upsert_user_by_oidc_user_oidc_put(
-        data=UpsertByOIDCRequest(
-            oidc_sub=claims.sub,
-            oidc_iss=claims.iss,
-            email=claims.email,
-            display_name=claims.given_name or claims.name or claims.nickname,
-            preferred_username=claims.nickname or claims.name or claims.given_name,
-        ),
-    )
+    try:
+        user = await user_client.upsert_user_by_oidc_user_oidc_put(
+            data=UpsertByOIDCRequest(
+                oidc_sub=claims.sub,
+                oidc_iss=claims.iss,
+                email=claims.email,
+                display_name=claims.given_name or claims.name or claims.nickname,
+                preferred_username=claims.nickname or claims.name or claims.given_name,
+            ),
+        )
+    except Exception as e:
+        raise IdentificationError("User upsert failed") from e
 
     return IdentityContext(
         token=token,

--- a/src/ab_core/identity_context/models.py
+++ b/src/ab_core/identity_context/models.py
@@ -4,8 +4,6 @@ from ab_client.token_validator import ValidatedOIDCClaims
 from ab_client.user import User
 from pydantic import BaseModel, Field
 
-from ab_core.dependency.pydanticize import pydanticize_type
-
 
 class IdentityContext(BaseModel):
     """Per-request identity context resolved from the bearer token."""


### PR DESCRIPTION
Bump version to 0.2.1 and enhance identity resolution flow.

- pyproject.toml: version -> 0.2.1
- dependency.get_identity_context: accept access_token cookie (Cookie alias) and fall back to Authorization Bearer header; prefer cookie over header; update docstring and 401 detail to "Missing access token".
- identify.py: wrap token validation and user upsert calls in try/except and raise IdentificationError with clearer messages; tidy imports.
- models.py: remove unused pydanticize_type import.

These changes add cookie-based token support and provide more robust error handling when external client calls fail.